### PR TITLE
create a clone of the input data array at row 0 prior to swapping ele…

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function MLLPServer(host, port, logger) {
             //get message ID
             var msg_id = data[0][10];
 
-            var header = [data[0]];
+            var header = [data[0].slice()];
 
             //switch around sender/receiver names
             header[0][3] = data[0][5];


### PR DESCRIPTION
…ments

The original line 51 in index.js creates a reference of data[0] and puts it in header.
elements 3, 4 isn't swapped with elements 5, 6.  You would end up with:
elements 5, 6, 5, 6 instead.

This change would use .slice() call to create a shallow copy of data[0].
The swap will now be successful.